### PR TITLE
Fix: Remove duplicate repository import in main.go

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aebalz/daily-vibe-tracker/internal/config"
 	"github.com/aebalz/daily-vibe-tracker/internal/handler"
 	"github.com/aebalz/daily-vibe-tracker/internal/repository"
-	"github.com/aebalz/daily-vibe-tracker/internal/repository"
 	"github.com/aebalz/daily-vibe-tracker/internal/service"
 	"github.com/aebalz/daily-vibe-tracker/pkg/cache"
 	"github.com/aebalz/daily-vibe-tracker/pkg/database"


### PR DESCRIPTION
Removed a duplicate import statement for 'internal/repository' in cmd/server/main.go, which would cause a compilation error.